### PR TITLE
Trafficmatching

### DIFF
--- a/lib/puppet/provider/f5_virtualserver.rb
+++ b/lib/puppet/provider/f5_virtualserver.rb
@@ -226,6 +226,7 @@ class Puppet::Provider::F5Virtualserver < Puppet::Provider::F5
   # destination may contain an IPV4 or IPV6 address
 
   def self.address_and_port(destination)
+    # destination maybe ':0' only in case of trafficMatchingCriteria
     if destination.split('/').count < 2
       raise ArgumentError, "Unexpected format for destination address and port, got '#{destination}'"
     end
@@ -241,6 +242,11 @@ class Puppet::Provider::F5Virtualserver < Puppet::Provider::F5
     else
       raise ArgumentError, "Unexpected format for destination address and port, got '#{destination}'"
     end
+    if destination.split(':').count < 2
+      address = nil
+      Puppet.notice("address_and_port returning address nil cause simple destination: '#{destination}'")
+    end
+
     port = '*' if port.to_i.zero?
     [address, port]
   end

--- a/lib/puppet/provider/f5_virtualserver.rb
+++ b/lib/puppet/provider/f5_virtualserver.rb
@@ -226,9 +226,7 @@ class Puppet::Provider::F5Virtualserver < Puppet::Provider::F5
   # destination may contain an IPV4 or IPV6 address
 
   def self.address_and_port(destination)
-    if destination.split('/').count < 2
-      raise ArgumentError, "Unexpected format for destination address and port, got '#{destination}'"
-    end
+    # destination maybe ':0' only in case of trafficMatchingCriteria
     address_and_port = destination.split('/')[-1]
     if (matched = address_and_port.match(/(?<address>.*?)\:(?<port>\d+)$/))
       # IPV4
@@ -241,6 +239,11 @@ class Puppet::Provider::F5Virtualserver < Puppet::Provider::F5
     else
       raise ArgumentError, "Unexpected format for destination address and port, got '#{destination}'"
     end
+    if destination.split(':').count < 2
+      address = nil
+      Puppet.notice("address_and_port returning address nil cause simple destination: '#{destination}'")
+    end
+
     port = '*' if port.to_i.zero?
     [address, port]
   end

--- a/lib/puppet/provider/f5_virtualserver/standard.rb
+++ b/lib/puppet/provider/f5_virtualserver/standard.rb
@@ -42,6 +42,9 @@ Puppet::Type.type(:f5_virtualserver).provide(:standard, parent: Puppet::Provider
 
     virtualservers.each do |vserver|
       destination_address, destination_port = address_and_port(vserver['destination'])
+      if vserver['trafficMatchingCriteria']
+        Puppet.notice("VS uses traffic matching... expect no destination_address: '#{destination_address}' but port '#{destination_port}'" )
+      end
 
       if vserver["vlansEnabled"]
         vlan_and_tunnel_traffic = { "enabled" => vserver["vlans"], }


### PR DESCRIPTION
When virtual server use traffic matching, the destination address looks a lot different. Just ':0' and not '/partition/destination:port'. The function address_and_port needs to take care not to fail if called with ':0' like values. Printing the value with a notice may help to realize what is going on.